### PR TITLE
Added implicit conversion in validation pipe

### DIFF
--- a/src/modules/Channels/Channels.service.ts
+++ b/src/modules/Channels/Channels.service.ts
@@ -6,7 +6,7 @@
  */
 
 import { getCustomRepository } from 'typeorm';
-import { Channels } from '../../database/entity/Channels';
+import { Channels } from '../../database';
 import { Injectable, NotFoundException, InternalServerErrorException } from '@nestjs/common';
 import { Transactional } from 'typeorm-transactional-cls-hooked';
 import { ChannelsRepository } from './Channels.repository';

--- a/src/pipes/validation.pipe.ts
+++ b/src/pipes/validation.pipe.ts
@@ -1,5 +1,5 @@
 /**
- * @description Created this custom validation pipe
+ * @description Updated the pipe to allow implicit conversion
  *
  * @author Shreyash <pandeyshreyash2201@gmail.com>
  */
@@ -14,7 +14,7 @@ export class ValidationPipe implements PipeTransform<any> {
 		if (!metatype || !this.toValidate(metatype)) {
 			return value;
 		}
-		const object = plainToClass(metatype, value);
+		const object = plainToClass(metatype, value, { enableImplicitConversion: true });
 		const errors = await validate(object);
 		if (errors.length > 0) {
 			throw new BadRequestException('Validation failed');


### PR DESCRIPTION
## Pull request checklist

Please check if your PR :rocket: fulfills the following requirements:
- [x] Build (`npm run start`) was run locally and new changes were working correctly


## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [x] Feature

## What is the current behavior?
-The Validation Pipe throws and error on sending "1" instead of 1

Fixes #55 

## What is the new behavior?
-Sending "1" will convert the string to a number and then save it. No errors will be thrown.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
There was some problem in import of channels, I fixed it by refactoring the code in channels.services
